### PR TITLE
Reduce space between contact button and about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         </header>
 
         <!-- Hero Section -->
-        <section class="min-h-screen flex flex-col justify-center items-center text-center px-6 py-16">
+        <section class="flex flex-col justify-center items-center text-center px-6 py-16">
             <div class="relative mb-8">
                 <img
                     src="https://avatars.githubusercontent.com/u/40253?v=4"
@@ -76,7 +76,7 @@
         </section>
 
         <!-- About Section -->
-        <section id="about" class="px-6 py-24 max-w-4xl mx-auto">
+        <section id="about" class="px-6 py-12 max-w-4xl mx-auto">
             <div class="flex items-center gap-3 mb-8">
                 <span class="font-mono text-elixir-purple text-2xl">defmodule</span>
                 <h2 class="text-3xl font-semibold text-elixir-dark">About</h2>


### PR DESCRIPTION
## Summary
- Removed `min-h-screen` from hero section to prevent excessive vertical space
- Reduced about section padding from `py-24` to `py-12` for better visual flow

## Test plan
- [x] Verify the contact button and about section have reduced spacing
- [x] Confirm the hero section still displays properly without full viewport height
- [x] Check responsive behavior on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)